### PR TITLE
Use Jakarta names instead of old accronyms

### DIFF
--- a/spec/src/main/asciidoc/chapters/1_overview.adoc
+++ b/spec/src/main/asciidoc/chapters/1_overview.adoc
@@ -267,13 +267,13 @@ the principals of the caller are contained in the `AccessControlContext` associa
 which the call to `checkPermission` is made.
 
 [[a160]]
-=== Servlet or EJB only containers
+=== Jakarta Servlet or Jakarta Enterprise Beans only containers
 
 The requirements of this specification that must be satisfied by a target platform that is a compatible
 implementation of one but not both of the Jakarta Servlet and Jakarta Enterprise Beans specifications
 are reduced as described in the next two sections.
 
-=== Servlet Only Containers
+=== Jakarta Servlet Only Containers
 
 A platform that is a compatible implementation of the Jakarta Servlet specification and that is not a compatible
 implementation of the Jakarta Enterprise Beans specification must satisfy all of the requirements of this 
@@ -285,10 +285,10 @@ specification with the following exceptions:
 
 . the policy context handler requirements defined in <<a719>>, and <<a723>>, and <<a725>>
 
-=== EJB Only Containers
+=== Jakarta Enterprise Beans Only Containers
 
 A platform that is is a compatible implementation of the Jakarta Enterprise beans specification and that is not a compatible
-implementation of the Jakara Servlet specification must satisfy all of the requirements of this specification with the following 
+implementation of the Jakarta Servlet specification must satisfy all of the requirements of this specification with the following
 exceptions:
 
 . the policy configuration requirements defined in <<a271>> and in <<a276>>

--- a/spec/src/main/asciidoc/chapters/4_policy-decision.adoc
+++ b/spec/src/main/asciidoc/chapters/4_policy-decision.adoc
@@ -586,7 +586,7 @@ bean implementation class does not implement the
 [[a725]]
 ===== Jakarta Enterprise Beans Arguments Policy Context Handler
 
-All EJB containers must register a
+All Jakarta Enterprise Beans containers must register a
 `PolicyContextHandler` whose `getContext` method returns an array of objects
 (`Object[]`) containing the arguments of the Jakarta Enterprise Beans method invocation (in the
 same order as they appear in the method signature) when invoked with the

--- a/spec/src/main/asciidoc/footnotes.txt
+++ b/spec/src/main/asciidoc/footnotes.txt
@@ -10,11 +10,11 @@ determine when a collection contains all the permissions implied by a
 wild carded form of the permission).
 
 [.footnoteNumber]# 2.# [[a1251]]An exception to this
-rule is described in link:jacc.html#a512[See EJB Policy Context
+rule is described in link:jacc.html#a512[See Jakarta Enterprise Beans Policy Context
 Identifiers]”.
 
 [.footnoteNumber]# 3.# [[a1252]]See
-link:jacc.html#a512[See EJB Policy Context Identifiers]” for
+link:jacc.html#a512[See Jakarta Enterprise Beans Policy Context Identifiers]” for
 further clarification.
 
 [.footnoteNumber]# 4.# [[a1253]]This can be achieved
@@ -72,7 +72,7 @@ inclusion of security-role-ref elements in entity and session elements.
 Future versions could support inclusion in message-driven.
 
 [.footnoteNumber]# 14.# [[a1263]]For example, if an
-application declares roles \{R1, R2, R3} and defines a session EJB named
+application declares roles \{R1, R2, R3} and defines a session Jakarta Enterprise Beans named
 “shoppingCart” that contains one security-role-ref __ element with
 role-name R1, then an additional EJBRoleRefPermission must be added to
 each of the roles R2 and R3. The name of both permissions must be
@@ -90,7 +90,7 @@ any can be committed.
 [.footnoteNumber]# 16.# [[a1265]]Such as having a
 Servlet 3.0 ServletContextListener configured that could
 programmatically register a servlet and configure its security
-constraints and that could also perform a local invocation of an EJB in
+constraints and that could also perform a local invocation of an Jakarta Enterprise Beans in
 another module of the application.
 
 [.footnoteNumber]# 17.# [[a1266]]The


### PR DESCRIPTION
The goal of this PR is to fix a small typo in Jakarta.
But it also includes some changes related to naming. Outside of the revision history, I renamed EJB to Jakarta Enterprise Beans, so there is no confusion and it looks more consistent.

What do you think?

Signed-off-by: Jean-Louis Monteiro <jlmonteiro@tomitribe.com>