### PR TITLE
Tidy up for M1 release

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,1 @@
+/.flattened-pom.xml

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,7 +24,7 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
         <relativePath/>
     </parent>
 
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>6.0.0</version>
+            <version>6.1.0-M1</version>
         </dependency>
     </dependencies>
 
@@ -166,7 +166,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>21</release>
+                    <release>17</release>
                     <compilerArgument>-Xlint:unchecked</compilerArgument>
                 </configuration>
             </plugin>
@@ -175,7 +175,7 @@
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
-                <version>2.1</version>
+                <version>2.2</version>
                 <configuration>
                     <spec>
                         <specVersion>3.0</specVersion>

--- a/api/src/main/java/jakarta/security/jacc/PolicyFactory.java
+++ b/api/src/main/java/jakarta/security/jacc/PolicyFactory.java
@@ -135,7 +135,7 @@ public abstract class PolicyFactory {
      * {@link Policy} and there must be at most one actual instance of a {@link Policy} with a given policy
      * context identifier (during a process context).
      *
-     * @param contextID A String identifying the policy context whose {@link Policy} interface is to be returned. The
+     * @param contextId A String identifying the policy context whose {@link Policy} interface is to be returned. The
      * value passed to this parameter can be null, which corresponds to the system-wide default {@link Policy} instance.
      *
      *
@@ -150,7 +150,7 @@ public abstract class PolicyFactory {
      * <p>
      * If an implementation was set previously, it will be replaced.
      *
-     * @param contextID A String identifying the policy context whose {@link Policy} interface is to be returned. The
+     * @param contextId A String identifying the policy context whose {@link Policy} interface is to be returned. The
      * value passed to this parameter can be null, which corresponds to the system-wide default {@link Policy} instance.
      *
      * @param policy The policy instance, which may be null.

--- a/api/src/main/java/jakarta/security/jacc/PrincipalMapper.java
+++ b/api/src/main/java/jakarta/security/jacc/PrincipalMapper.java
@@ -93,7 +93,7 @@ public interface PrincipalMapper {
      * For instance, if a Principal representing the group "adm" is present in the Subject, and the group "adm" is
      * mapped (in a implementation specific way) to "administrator", then "administrator" must be returned here.
      *
-     * @param subject the subject from which the roles are to be retrieved.
+     * @param principals the set of principals from which the roles are to be retrieved.
      * @return a set of logical application roles associated with the caller principal.
      */
     default Set<String> getMappedRoles(Set<Principal> principals) {


### PR DESCRIPTION
- Update spec plugin to 2.2 so we can actually release an M1
- Address javadoc errors
- Update Servlet dependency to 6.1.0-M1
- Set JDK to 17 for now, to allow broader testing (will be 21 again later)